### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/pub_on_release.yaml
+++ b/.github/workflows/pub_on_release.yaml
@@ -39,14 +39,14 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::$(echo ${GITHUB_REF:11})
       - name: Build and Publish Site to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.DOCKER_LOGIN }}/${{ secrets.DOCKER_NAME }}
           username: ${{ secrets.DOCKER_LOGIN }}
           password: ${{ secrets.DOCKER_PWD }}
           tags: "latest,${{ steps.get_version.outputs.VERSION }}"
       - name: Build and Publish Telegram Bot to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.DOCKER_LOGIN }}/${{ secrets.DOCKER_NAME }}
           username: ${{ secrets.DOCKER_LOGIN }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore